### PR TITLE
fix typo at docs

### DIFF
--- a/docs/.sections/form-fields.md
+++ b/docs/.sections/form-fields.md
@@ -68,7 +68,7 @@ You can also rename the content section by passing a `contentFieldsetLabel` prop
 | :---------- | :------------------------------------------------------------------------------------------------------------------------| :------------------------------------------------- | :------------ |
 | name        | Name of the field                                                                                                        | string                                             |               |
 | label       | Label of the field                                                                                                       | string                                             |               |
-| type        | Type of input field                                                                                                      | text<br/>texarea<br/>email<br/>number<br/>password | text          |
+| type        | Type of input field                                                                                                      | text<br/>textarea<br/>email<br/>number<br/>password | text          |
 | translated  | Defines if the field is translatable                                                                                     | true<br/>false                                     | false         |
 | maxlength   | Max character count of the field                                                                                         | integer                                            |               |
 | note        | Hint message displayed above the field                                                                                   | string                                             |               |


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->
Fix typo `texarea` => `textarea`
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
- Docs
   - Form fields
          - input