### PR TITLE
set correct block class name

### DIFF
--- a/docs/src/block-editor/block-classes.md
+++ b/docs/src/block-editor/block-classes.md
@@ -7,7 +7,7 @@ pageClass: twill-doc
 If you need more control over blocks, their validation or data for rendering you can use a block class.
 
 To do this create a file named after your block. (ex. for `images_grid.blade.php` your class will be
-`ImagesGrid`)
+`ImagesGridBlock`)
 
 A block class extends `A17\Twill\Services\Blocks\Block` and they are expected to be in the `App\Twill\Block` namespace:
 


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
Class name should be `ImagesGridBlock` instead of `ImagesGrid`. Even if it can be known from the code example but it's misleading to have it in 2 forms so it should be set clear that it must have `Block` suffix

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
